### PR TITLE
typo fix, changed 'too' to 'to'

### DIFF
--- a/docs/discover-program-template-project/getting-started.md
+++ b/docs/discover-program-template-project/getting-started.md
@@ -20,7 +20,7 @@ if you are not the member of your team responsible for setting up the starter te
 
 ### Forking the Template Repositories
 
-Next, you need too:
+Next, you need to:
 
 1. Navigate to the template repositories:
    - Frontend: https://github.com/disc-template/frontend


### PR DESCRIPTION
Summary
- Fixed a spelling error: changed "too" to "to" in the documentation for the discover program template
File Updated
- docs/discover-program-template-project/getting-started.md
Type of Change
- Doc update
How To Test
- No testing required - it's just a text correction
